### PR TITLE
Update GH action and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Fixes # (issue)
 
 Please check only the options that are relevant.
 
+- [ ] General Maintenance
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - edge
       - stable
+  workflow_dispatch:
 
 jobs:
   snap:


### PR DESCRIPTION
# Pull Request Template

## Description

I added a `workflow_dispatch:` line to the .github/workflows/build.yaml so that one can manually run the GH action without submitting a PR.

## Type of change

Please check only the options that are relevant.

- [x] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This change has already been applied to other repositories (see [libreoffice](https://github.com/ubuntu/libreoffice) and it is known to be fine.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

